### PR TITLE
expose options for re-reading unacked messages

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -235,8 +235,8 @@ func (c *Consumer) handleReachedEndOfTopic(f frame.Frame) error {
 	return nil
 }
 
-// RedeliverUnacknowledged sends of REDELIVER_UNACKNOWLEDGED_MESSAGES request
-// for all messages that have not been acked.
+// RedeliverUnacknowledged uses the protocol option
+// REDELIVER_UNACKNOWLEDGED_MESSAGES to re-retrieve unacked messages.
 func (c *Consumer) RedeliverUnacknowledged(ctx context.Context) error {
 	cmd := api.BaseCommand{
 		Type: api.BaseCommand_REDELIVER_UNACKNOWLEDGED_MESSAGES.Enum(),

--- a/managed_consumer.go
+++ b/managed_consumer.go
@@ -340,7 +340,7 @@ func (m *ManagedConsumer) manage() {
 	}
 }
 
-// RedeliverUnacknowledged requests redeliver_unacknowledged_messages request
+// RedeliverUnacknowledged sends of REDELIVER_UNACKNOWLEDGED_MESSAGES request
 // for all messages that have not been acked.
 func (m *ManagedConsumer) RedeliverUnacknowledged(ctx context.Context) error {
 	for {
@@ -367,7 +367,7 @@ func (m *ManagedConsumer) RedeliverUnacknowledged(ctx context.Context) error {
 	}
 }
 
-// RedeliverOverflow sends of redeliver_unacknowledged_messages request
+// RedeliverOverflow sends of REDELIVER_UNACKNOWLEDGED_MESSAGES request
 // for all messages that were dropped because of full message buffer. Note that
 // for all subscription types other than `shared`, _all_ unacknowledged messages
 // will be redelivered.
@@ -398,7 +398,7 @@ func (m *ManagedConsumer) RedeliverOverflow(ctx context.Context) (int, error) {
 	}
 }
 
-// Unsubscribe from topic for reacquisition of shared queue
+// Unsubscribe the consumer from its topic.
 func (m *ManagedConsumer) Unsubscribe(ctx context.Context) error {
 	for {
 		m.mu.RLock()

--- a/managed_consumer.go
+++ b/managed_consumer.go
@@ -359,11 +359,7 @@ func (m *ManagedConsumer) RedeliverUnacknowledged(ctx context.Context) error {
 				return ctx.Err()
 			}
 		}
-
-		if err := consumer.RedeliverUnacknowledged(ctx); err != nil {
-			return err
-		}
-		return nil
+		return consumer.RedeliverUnacknowledged(ctx)
 	}
 }
 
@@ -389,12 +385,7 @@ func (m *ManagedConsumer) RedeliverOverflow(ctx context.Context) (int, error) {
 				return -1, ctx.Err()
 			}
 		}
-		var i int
-		var err error
-		if i, err = consumer.RedeliverOverflow(ctx); err != nil {
-			return -1, err
-		}
-		return i, nil
+		return consumer.RedeliverOverflow(ctx)
 	}
 }
 
@@ -416,9 +407,6 @@ func (m *ManagedConsumer) Unsubscribe(ctx context.Context) error {
 				return ctx.Err()
 			}
 		}
-		if err := consumer.Unsubscribe(ctx); err != nil {
-			return err
-		}
-		return nil
+		consumer.Unsubscribe(ctx)
 	}
 }


### PR DESCRIPTION
redeliver un-acked queue messages to the subscriber if it re-reads after executing RedeliverUnacknowledged on the current managed consumer

The internal methods 
```
func (*Consumer) RedeliverUnacknowledged(ctx context.Context)
func (*Consumer) RedeliverOverflow(ctx context.Context)
func (*Consumer) Unsubscribe(ctx context.Context)
```
are non-public but are helpful for managing topics.

This PR creates public counterparts  on `ManagedConsumer` like 
```
func (m *ManagedConsumer) RedeliverUnacknowledged(ctx context.Context)
func (m *ManagedConsumer) RedeliverOverflow(ctx context.Context)
func (m *ManagedConsumer) Unsubscribe(ctx context.Context)
```

They are wrapped in synchronizations to be concurrency safe.