### PR TITLE
export close for flows that require reconnect semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- export close for flows that require reconnect semantics
+- expose options for re-reading unacked messages
 
 ## [v0.1.0] - 2018-07-27
 - Initial release of this library

--- a/managed_consumer.go
+++ b/managed_consumer.go
@@ -312,7 +312,7 @@ func (m *ManagedConsumer) reconnect(initial bool) *Consumer {
 	}
 }
 
-// manage monitors the Consumer for conditions
+// manage Monitors the Consumer for conditions
 // that require it to be recreated.
 func (m *ManagedConsumer) manage() {
 	defer m.unset()
@@ -407,6 +407,18 @@ func (m *ManagedConsumer) Unsubscribe(ctx context.Context) error {
 				return ctx.Err()
 			}
 		}
-		consumer.Unsubscribe(ctx)
+		return consumer.Unsubscribe(ctx)
 	}
+}
+
+// Monitor a scoped deferrable lock
+func (m *ManagedConsumer) Monitor() func() {
+	m.mu.Lock()
+	return m.mu.Unlock
+}
+
+// Close consumer
+func (m *ManagedConsumer) Close(ctx context.Context) error {
+	defer m.Monitor()()
+	return m.consumer.Close(ctx)
 }

--- a/managed_producer.go
+++ b/managed_producer.go
@@ -177,7 +177,7 @@ func (m *ManagedProducer) reconnect(initial bool) *Producer {
 	}
 }
 
-// managed monitors the Producer for conditions
+// managed Monitors the Producer for conditions
 // that require it to be recreated.
 func (m *ManagedProducer) manage() {
 	defer m.unset()
@@ -195,4 +195,16 @@ func (m *ManagedProducer) manage() {
 		producer = m.reconnect(false)
 		m.set(producer)
 	}
+}
+
+// Monitor a scoped deferrable lock
+func (m *ManagedProducer) Monitor() func() {
+	m.mu.Lock()
+	return m.mu.Unlock
+}
+
+// Close producer
+func (m *ManagedProducer) Close(ctx context.Context) error {
+	defer m.Monitor()()
+	return m.producer.Close(ctx)
 }


### PR DESCRIPTION
standard flows monitoring a pulsar queue can probably dispense with accessing these apis, re-reading unacked messages is sufficient for restarting a read in 'normal' flows